### PR TITLE
feat: Allow notebooks repo to write and create PRs in this docs repo

### DIFF
--- a/.github/repository_access_permissions.json
+++ b/.github/repository_access_permissions.json
@@ -1,0 +1,5 @@
+{
+  "repositories": {
+    "qctrl/notebooks": "write"
+  }
+}


### PR DESCRIPTION
Addresses: https://qctrl.atlassian.net/browse/INFRA-3915

Changes proposed in this pull request:

- Adds a .github/repository_access_permissions.json file to allow permissions for the notebooks repo to push directly without the use of deploy keys.
